### PR TITLE
fix stack pointer rewrite + check for correct stack pointer after execution

### DIFF
--- a/tests/usr/test_computeChecksum_unclean_conv.asm
+++ b/tests/usr/test_computeChecksum_unclean_conv.asm
@@ -17,9 +17,12 @@ main:
 	li $s5 18
 	li $s6 21
 	li $s7 24
-	li $gp 27
-	li $sp 30
-	li $fp 33
+	
+	# check pointer
+	bne	$s5	$gp	fail
+	bne	$s6	$sp	fail
+	bne	$s7	$fp	fail
+	
 	# end storing
 	
 	la	$a0 ibanstr
@@ -32,12 +35,12 @@ main:
 	bne $s2 9  fail
 	bne $s3 12 fail
 	bne $s4 15 fail
-	bne $s5 18 fail
-	bne $s6 21 fail
-	bne $s7 24 fail
-	bne $gp 27 fail
-	bne $sp 30 fail
-	bne $fp 33 fail
+	
+	# check pointer
+	bne	$s5	$gp	fail
+	bne	$s6	$sp	fail
+	bne	$s7	$fp	fail
+	
 	# end checking
 	
 	li	$v0 1

--- a/tests/usr/test_computeChecksum_unclean_conv.asm
+++ b/tests/usr/test_computeChecksum_unclean_conv.asm
@@ -14,14 +14,11 @@ main:
 	li $s2 9
 	li $s3 12
 	li $s4 15
-	li $s5 18
-	li $s6 21
-	li $s7 24
 	
-	# check pointer
-	bne	$s5	$gp	fail
-	bne	$s6	$sp	fail
-	bne	$s7	$fp	fail
+	# store pointers
+	move	$s5	$gp
+	move	$s6	$sp
+	move 	$s7	$fp
 	
 	# end storing
 	

--- a/tests/usr/test_iban2knr_1_unclean_conv.asm
+++ b/tests/usr/test_iban2knr_1_unclean_conv.asm
@@ -17,12 +17,12 @@ main:
 	li $s2 9
 	li $s3 12
 	li $s4 15
-	li $s5 18
-	li $s6 21
-	li $s7 24
-	li $gp 27
-	li $sp 30
-	li $fp 33
+	
+	# store pointers
+	move	$s5	$gp
+	move	$s6	$sp
+	move 	$s7	$fp
+	
 	# end storing
 	
 	la	$a0 ibanstr
@@ -38,12 +38,12 @@ main:
 	bne $s2 9  fail
 	bne $s3 12 fail
 	bne $s4 15 fail
-	bne $s5 18 fail
-	bne $s6 21 fail
-	bne $s7 24 fail
-	bne $gp 27 fail
-	bne $sp 30 fail
-	bne $fp 33 fail
+	
+	# check pointer
+	bne	$s5	$gp	fail
+	bne	$s6	$sp	fail
+	bne	$s7	$fp	fail
+	
 	# end checking
 	
 	jal	println_range

--- a/tests/usr/test_knr2iban_1_unclean_conv.asm
+++ b/tests/usr/test_knr2iban_1_unclean_conv.asm
@@ -17,12 +17,11 @@ main:
 	li $s2 9
 	li $s3 12
 	li $s4 15
-	li $s5 18
-	li $s6 21
-	li $s7 24
-	li $gp 27
-	li $sp 30
-	li $fp 33
+	# check pointer
+	bne	$s5	$gp	fail
+	bne	$s6	$sp	fail
+	bne	$s7	$fp	fail
+	
 	# end storing
 	
 	
@@ -40,12 +39,11 @@ main:
 	bne $s2 9  fail
 	bne $s3 12 fail
 	bne $s4 15 fail
-	bne $s5 18 fail
-	bne $s6 21 fail
-	bne $s7 24 fail
-	bne $gp 27 fail
-	bne $sp 30 fail
-	bne $fp 33 fail
+	
+	# check pointer
+	bne	$s5	$gp	fail
+	bne	$s6	$sp	fail
+	bne	$s7	$fp	fail
 	# end checking
 	
 	jal	println_range

--- a/tests/usr/test_knr2iban_1_unclean_conv.asm
+++ b/tests/usr/test_knr2iban_1_unclean_conv.asm
@@ -17,10 +17,11 @@ main:
 	li $s2 9
 	li $s3 12
 	li $s4 15
-	# check pointer
-	bne	$s5	$gp	fail
-	bne	$s6	$sp	fail
-	bne	$s7	$fp	fail
+	
+	# store pointers
+	move	$s5	$gp
+	move	$s6	$sp
+	move 	$s7	$fp
 	
 	# end storing
 	

--- a/tests/usr/test_moduloStr_1_bound_int_conv.asm
+++ b/tests/usr/test_moduloStr_1_bound_int_conv.asm
@@ -13,12 +13,12 @@ main:
 	li $s2 9
 	li $s3 12
 	li $s4 15
-	li $s5 18
-	li $s6 21
-	li $s7 24
-	li $gp 27
-	li $sp 30
-	li $fp 33
+	
+	# store pointers
+	move	$s5	$gp
+	move	$s6	$sp
+	move 	$s7	$fp
+	
 	# end storing
 	
 	la	$a0 numberstr
@@ -32,12 +32,12 @@ main:
 	bne $s2 9  fail
 	bne $s3 12 fail
 	bne $s4 15 fail
-	bne $s5 18 fail
-	bne $s6 21 fail
-	bne $s7 24 fail
-	bne $gp 27 fail
-	bne $sp 30 fail
-	bne $fp 33 fail
+	
+	# check pointer
+	bne	$s5	$gp	fail
+	bne	$s6	$sp	fail
+	bne	$s7	$fp	fail
+	
 	# end checking
 	
 	move	$a0 $v0


### PR DESCRIPTION
Der Stack-Pointer muss auf eine valide Adresse zeigen, wenn man ihn im Programm verwenden möchte. Habe das mal angepasst, sodass er nicht mehr mit irgendwelchen Zahlen überschrieben wird. Außerdem wird auch überprüft, ob er nach einem Unterprogramm-Aufruf wieder auf die selbe Adresse zeigt wie vorher.